### PR TITLE
Refactor routes and add search template

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     - Javascript
     - HTML/CSS
     - Postgres
-    
+
 ## Setting up your development environment for local testing
 
     - Ensure dependencies are available (activate environment as necessary)
@@ -30,5 +30,7 @@
     - change to the directory with manage.py in it
     - run `python manage.py migrate` to create database tables
     - run `python manage.py runserver`
-    - open browser to http://localhost:8000/movies
-    
+    - open browser to http://localhost:8000/
+    - run all tests with `python manage.py test`
+    - run unit tests only with `python manage.py test movies`
+

--- a/moviemvp/urls.py
+++ b/moviemvp/urls.py
@@ -17,6 +17,6 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path('movies/', include('movies.urls')),
+    path('', include('movies.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/movies/templates/movies/search.html
+++ b/movies/templates/movies/search.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Movie Search</title>
+</head>
+<body>
+    <h2>Movie Search Results</h2>
+
+    <div id="id_movie_results">
+
+    {% if movie_results %}
+
+        <table id="id_movie_table">
+        {% for movie in movie_results %}
+            <tr>
+                <td>
+                    <a href="/detail/{{movie.imdb_id}}">
+                        <img src="{{ movie.img_url}}">
+                    </a>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <h4>{{movie.title}}</h4>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <h5>Released: {{movie.release_date}}</h5>
+                </td>
+            </tr>
+        {% endfor %}
+        </table>
+
+    {% else %}
+
+        <p id="id_no_results">No results found. <a href='/'>Search again?</a></p>
+
+    {% endif %}
+    </div>
+</body>
+</html>

--- a/movies/tests.py
+++ b/movies/tests.py
@@ -6,19 +6,19 @@ class HomePageTest(TestCase):
 
     def test_uses_index_template(self):
 
-        response = self.client.get('/movies/')
+        response = self.client.get('/')
         self.assertTemplateUsed(response, 'movies/index.html')
 
     def test_can_save_a_POST_request(self):
 
-        response = self.client.post('/movies/', data={'movie_title': 'A Movie Title'})
+        response = self.client.post('/', data={'movie_title': 'A Movie Title'})
         self.assertEqual(Movie.objects.count(), 1)
         new_movie = Movie.objects.first()
         self.assertEqual(new_movie.title, 'A Movie Title')
 
     def test_redirects_after_POST(self):
 
-        response = self.client.post('/movies/', data={'movie_title': 'A Movie Title'})
+        response = self.client.post('/', data={'movie_title': 'A Movie Title'})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['location'], '/movies/')
 
@@ -27,15 +27,35 @@ class HomePageTest(TestCase):
         Movie.objects.create(title='Galaxy Quest')
         Movie.objects.create(title='Clue')
 
-        response = self.client.get('/movies/')
+        response = self.client.get('/')
 
         self.assertContains(response, 'Galaxy Quest')
         self.assertContains(response, 'Clue')
 
     def test_only_saves_movies_when_necessary(self):
 
-        self.client.get('/movies/')
+        self.client.get('/')
         self.assertEqual(Movie.objects.count(), 0)
+
+
+class SearchPageTest(TestCase):
+
+    def test_uses_search_template(self):
+
+        response = self.client.get('/search/')
+        self.assertTemplateUsed(response, 'movies/search.html')
+
+    def test_displays_all_search_results(self):
+
+        pass  # add after api calls are working
+
+    def test_displays_no_results_message_as_needed(self):
+
+        pass  # add after api calls are working
+
+    def test_redirects_to_movie_detail_view(self):
+
+        pass  # add after api calls are working
 
 
 class MovieModelTest(TestCase):

--- a/movies/urls.py
+++ b/movies/urls.py
@@ -3,4 +3,6 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('search/', views.search, name='search'),
+    path('detail/', views.search, name='movie_detail')
 ]

--- a/movies/urls.py
+++ b/movies/urls.py
@@ -4,5 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('search/', views.search, name='search'),
-    path('detail/', views.search, name='movie_detail')
+    path('detail/', views.detail, name='movie_detail')
 ]

--- a/movies/views.py
+++ b/movies/views.py
@@ -20,6 +20,6 @@ def search(request):
     return render(request, 'movies/search.html')
 
 
-def detail(request, movie_id):
+def detail(request):
 
-    pass
+    return HttpResponse("<h1>Movie Detail View</h1>")

--- a/movies/views.py
+++ b/movies/views.py
@@ -13,3 +13,13 @@ def index(request):
     movies = Movie.objects.all()
 
     return render(request, 'movies/index.html', {'movie_list': movies})
+
+
+def search(request):
+
+    return render(request, 'movies/search.html')
+
+
+def detail(request, movie_id):
+
+    pass


### PR DESCRIPTION
Progress towards #7. This pull request changes the following:

Routes for the app:
- main page is at "/", not "movies/"
- adds "search/" to display movie search results - currently returns the new search.html template
- adds "detail/" to display an individual movie's details - currently returns HTML from views.py

README:
- updates main route info, and adds testing instructions

Unit tests:
- adds a basic test to determine if "/search/" returns the right template
- adds a few more tests related to the search view (to be implemented after API calls are working)

Template: 
- adds `movies/search.html` to display movie search results, also displays message if no results were found. 

All unit tests are passing at the moment.
